### PR TITLE
(feat) Craft 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "deuxhuithuit/craft-cloudflare-images",
   "description": "Upload your images assets to Cloudflare Images from Craft CMS assets interface. It exposes the a file system and supports craft image transforms.",
   "type": "craft-plugin",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "keywords": [
     "cloudflare",
     "images",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "docs": "https://github.com/DeuxHuitHuit/craft-cloudflare-images/blob/dev/README.md"
   },
   "require": {
-    "php": "^8.1|^8.2|^8.3",
-    "craftcms/cms": "^4.5.10"
+    "php": "^8.2|^8.3",
+    "craftcms/cms": "^5.0.0"
   },
   "require-dev": {
     "craftcms/ecs": "dev-main",

--- a/src/fs/CloudflareImagesFs.php
+++ b/src/fs/CloudflareImagesFs.php
@@ -249,7 +249,7 @@ class CloudflareImagesFs extends Fs
     /**
      * @inheritdoc
      */
-    public function renameFile(string $path, string $newPath): void
+    public function renameFile(string $path, string $newPath, array $config = []): void
     {
         try {
             $imageId = Filename::toId($path);
@@ -267,7 +267,7 @@ class CloudflareImagesFs extends Fs
     /**
      * @inheritdoc
      */
-    public function copyFile(string $path, string $newPath): void
+    public function copyFile(string $path, string $newPath, array $config = []): void
     {
         throw new FsException('Cloudflare Images does not support copying files');
     }


### PR DESCRIPTION
- Updated composer.json
- Updated `renameFile` and `copyFile` declarations. It doesn't really change anything, but was causing the CMS to crash.

Tested it on a local Craft 5 install and everything worked perfectly! 