### PR TITLE
(feat) Allow images to be moved across volume

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -101,7 +101,7 @@ class Plugin extends \craft\base\Plugin
                     $asset = $event->sender;
 
                     // If this asset is not using the Cloudflare Images volume, we don't need to do anything
-                    if (!$this->isAssetOnCloudflareImagesVolume($asset)) {
+                    if (!$this->isAssetOnCloudflareImagesFs($asset)) {
                         return;
                     }
 
@@ -112,6 +112,10 @@ class Plugin extends \craft\base\Plugin
 
                     // Detect if the file is being moved/renamed
                     if (!$asset->newLocation) {
+                        \Craft::debug(
+                            "No new location for {$asset->getFileName()} {$asset->id}",
+                            'cloudflare-images'
+                        );
                         return;
                     }
 
@@ -127,16 +131,20 @@ class Plugin extends \craft\base\Plugin
                 Asset::class,
                 Asset::EVENT_BEFORE_SAVE,
                 function (\craft\events\ModelEvent $event) {
-                    // If this isn't a new asset, we don't need to do anything
-                    if (!$this->isNewValidEvent($event)) {
-                        return;
-                    }
-
                     /** @var Asset $asset */
                     $asset = $event->sender;
 
                     // If this asset is not using the Cloudflare Images volume, we don't need to do anything
-                    if (!$this->isAssetOnCloudflareImagesVolume($asset)) {
+                    if (!$this->isAssetOnCloudflareImagesFs($asset)) {
+                        return;
+                    }
+
+                    // If this isn't a new asset nor a moved asset we don't need to do anything
+                    if (!$this->isNewValidEvent($event) && !$this->isMovedAssetImage($asset)) {
+                        \Craft::debug(
+                            "Not a new asset nor a moved asset {$asset->getFileName()} {$asset->id}",
+                            'cloudflare-images'
+                        );
                         return;
                     }
 
@@ -154,12 +162,39 @@ class Plugin extends \craft\base\Plugin
                     if (ElementHelper::isDraftOrRevision($asset)) {
                         return;
                     }
-                    if (!$this->isNewImageAsset($asset)) {
+
+                    // If this asset is not using the Cloudflare Images volume, we don't need to do anything
+                    if (!$this->isAssetOnCloudflareImagesFs($asset)) {
                         return;
                     }
-                    if ($this->isAssetOnCloudflareImagesVolume($asset)) {
-                        /** @var \deuxhuithuit\cfimages\fs\CloudflareImagesFs */
-                        $fs = $asset->getVolume()->getFs();
+
+                    /** @var \deuxhuithuit\cfimages\fs\CloudflareImagesFs */
+                    $fs = $asset->getVolume()->getFs();
+
+                    // Handle moved assets: Only act when the file is recent,
+                    // i.e. a write operation has been performed on it.
+                    // This is the case when a file is moved across volumes.
+                    if ($this->isMovedAssetImage($asset)) {
+                        if ($fs->isFileRecent($asset->getPath())) {
+                            \Craft::debug(
+                                "File is recent {$asset->getFileName()} {$asset->id}",
+                                'cloudflare-images'
+                            );
+                            $fs->saveAsset($asset);
+                        } else {
+                            \Craft::debug(
+                                "File is not recent {$asset->getFileName()} {$asset->id}",
+                                'cloudflare-images'
+                            );
+                        }
+                    }
+
+                    // This is a new image asset, we need to create it on Cloudflare Images
+                    else if ($this->isNewImageAsset($asset)) {
+                        \Craft::debug(
+                            "New image asset {$asset->getFileName()} {$asset->id}",
+                            'cloudflare-images'
+                        );
                         $fs->saveAsset($asset);
                     }
                 }
@@ -187,7 +222,7 @@ class Plugin extends \craft\base\Plugin
         );
     }
 
-    private function isAssetOnCloudflareImagesVolume(Asset $asset): bool
+    private function isAssetOnCloudflareImagesFs(Asset $asset): bool
     {
         return $asset->getVolume()->getFs() instanceof \deuxhuithuit\cfimages\fs\CloudflareImagesFs;
     }
@@ -205,6 +240,12 @@ class Plugin extends \craft\base\Plugin
     {
         return $this->isImageAsset($asset)
             && $asset->getScenario() === Asset::SCENARIO_CREATE;
+    }
+
+    private function isMovedAssetImage(?Asset $asset): bool
+    {
+        return $this->isImageAsset($asset)
+            && $asset->getScenario() === Asset::SCENARIO_MOVE;
     }
 
     private function isNewValidEvent(\craft\events\ModelEvent $event): bool

--- a/src/fs/CloudflareImagesFs.php
+++ b/src/fs/CloudflareImagesFs.php
@@ -330,4 +330,21 @@ class CloudflareImagesFs extends Fs
         // Left empty: Cloudflare do not support directories, let Craft handle it.
     }
     // #endregion
+
+    /**
+     * Returns true if the file is recent, i.e. a write operation has been performed on it.
+     * This is the case when the file its the Fs for the first time, either as
+     * a new asset or as a "moved from another volume" asset.
+     * It is also the case when the file is renamed.
+     *
+     * @see CloudflareImagesFs::writeFileFromStream()
+     * @see CloudflareImagesFs::renameFile()
+     *
+     * @param string $path The asset's path
+     * @return bool
+     */
+    public function isFileRecent(string $path): bool
+    {
+        return isset($this->recentFiles[$path]);
+    }
 }


### PR DESCRIPTION
Moves assets need to be considered "new" when they are moved from another volume.