### PR TITLE
(fix) Add account id validation in filename pasing

### DIFF
--- a/src/Filename.php
+++ b/src/Filename.php
@@ -9,11 +9,17 @@ class Filename
 {
     public const SEPARATOR = '.';
 
-    public static function toParts(string $filename): array
+    public static function toParts(string $filename, string $accountHash = null): array
     {
         $parts = \explode(static::SEPARATOR, $filename, 3);
         if (!isset($parts[2])) {
             throw new \Exception('Invalid filename: ' . $filename);
+        }
+        if (!isset($parts[0]) || !isset($parts[1])) {
+            throw new \Exception('Empty filename: ' . $filename);
+        }
+        if ($accountHash && $parts[0] !== $accountHash) {
+            throw new \Exception('Invalid account hash: ' . $parts[0]);
         }
         return [
             'account' => $parts[0],
@@ -22,9 +28,9 @@ class Filename
         ];
     }
 
-    public static function toId(string $filename): string
+    public static function toId(string $filename, string $accountHash = null): string
     {
-        $parts = static::toParts($filename);
+        $parts = static::toParts($filename, $accountHash);
         return $parts['id'];
     }
 

--- a/src/controllers/ViewController.php
+++ b/src/controllers/ViewController.php
@@ -10,8 +10,9 @@ class ViewController extends Controller
     {
         $this->requireCpRequest();
         $filename = \basename($file);
-        $imageId = \deuxhuithuit\cfimages\Filename::toId($filename);
-        $client = \deuxhuithuit\cfimages\Plugin::getInstance()->client();
+        $plugin = \deuxhuithuit\cfimages\Plugin::getInstance();
+        $imageId = \deuxhuithuit\cfimages\Filename::toId($filename, $plugin->getSettings()->getAccountHash());
+        $client = $plugin->client();
         $image = $client->getImage($imageId);
         $content = $client->getImageStream($imageId)->getContents();
         $this->response->format = \craft\web\Response::FORMAT_RAW;

--- a/src/fs/CloudflareImagesFs.php
+++ b/src/fs/CloudflareImagesFs.php
@@ -110,7 +110,7 @@ class CloudflareImagesFs extends Fs
     public function getFileSize(string $uri): int
     {
         try {
-            $imageId = Filename::toId($uri);
+            $imageId = Filename::toId($uri, $this->settings->getAccountHash());
             $image = $this->client->getImage($imageId);
             return $image['meta']['size'];
         } catch (\Exception $e) {
@@ -124,7 +124,7 @@ class CloudflareImagesFs extends Fs
     public function getDateModified(string $uri): int
     {
         try {
-            $imageId = Filename::toId($uri);
+            $imageId = Filename::toId($uri, $this->settings->getAccountHash());
             $image = $this->client->getImage($imageId);
             return isset($image['meta']['updated']) ? $image['meta']['updated'] : $image['meta']['created'];
         } catch (\Exception $e) {
@@ -219,7 +219,7 @@ class CloudflareImagesFs extends Fs
 
         // Check if the file exists in the cloudflare images
         try {
-            $imageId = Filename::toId(\basename($path));
+            $imageId = Filename::toId(\basename($path), $this->settings->getAccountHash());
             if (!$imageId) {
                 throw new \Exception('Failed to parse filename');
             }
@@ -245,7 +245,7 @@ class CloudflareImagesFs extends Fs
     {
         $imageId = null;
         try {
-            $imageId = Filename::toId($path);
+            $imageId = Filename::toId($path, $this->settings->getAccountHash());
             if (!$imageId) {
                 // Found an empty filename, let Craft handle it.
                 return;
@@ -267,7 +267,7 @@ class CloudflareImagesFs extends Fs
     public function renameFile(string $path, string $newPath, array $config = []): void
     {
         try {
-            $imageId = Filename::toId($path);
+            $imageId = Filename::toId($path, $this->settings->getAccountHash());
             $image = $this->client->getImage($imageId);
             // Make sure we get rid of any parts in the new paths.
             // This happens when the file is moved to another folder in the asset manager.
@@ -293,7 +293,9 @@ class CloudflareImagesFs extends Fs
     public function getFileStream(string $uriPath)
     {
         try {
-            return $this->client->getImageStream(Filename::toId($uriPath))->detach();
+            return $this->client->getImageStream(
+                Filename::toId($uriPath, $this->settings->getAccountHash())
+            )->detach();
         } catch (\Exception $e) {
             throw new FsException($e->getMessage(), $e->getCode(), $e);
         }


### PR DESCRIPTION
This should make sure files with 3 dots in their name wont cause problems.